### PR TITLE
fix color palette issue when <3 genotypes other than wt

### DIFF
--- a/reports/postprocessingQC.Rmd
+++ b/reports/postprocessingQC.Rmd
@@ -51,8 +51,12 @@ data = read_csv(file.path(datadir,'output_psII_level0.csv'), #reading the data f
 
 ```{r gtypeColors, include=F}
 # set your genotype color palette. 'black' is always WT 
-gtypeColors = c('black',RColorBrewer::brewer.pal(length(levels(data$gtype))-1,'Set2'))
-names(gtypeColors) <- levels(data$gtype)
+if( length(levels(data$gtype)) <= 9){
+  gtypeColors = c('black',RColorBrewer::brewer.pal(8,'Set2'))[1:length(levels(data$gtype))]
+  names(gtypeColors) <- levels(data$gtype)
+} else{
+  stop('You have more than 9 genotypes. You will need to add more colors to the color palette')
+}
 
 italic_labels <- function(names){
   if(is.factor(names)){


### PR DESCRIPTION
return all colors in palette and subset for number of gtypes instead of palette returning requested number of colors.  palette returns min 3 colors so if there are only 2 geno+WT then you previously got an NA.
also check there aren't too many genotypes.

closes #1 